### PR TITLE
Migrate build to mill-crossplatform

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -79,167 +79,158 @@ trait CommonPublishNativeModule extends CommonPublishModule with ScalaNativeModu
     def scalaNativeVersion = versions.scalaNative
     trait CommonPublishCrossModuleTests extends CommonPublishTestModule with Tests
 }
+object poppet extends Module {
+    override def millSourcePath = super.millSourcePath / os.up
+    object core extends Cross[CoreModule](versions.cross: _*)
+    class CoreModule(val crossScalaVersion: String) extends CrossPlatform {
+        trait CommonModule extends CrossPlatformCrossScalaModule with CommonPublishModule {
+            trait CommonModuleTests extends Tests {
+                override def ivyDeps = super.ivyDeps() ++ Agg(
+                    ivy"com.lihaoyi::upickle::${versions.upickle}",
+                )
+            }
+        }
 
-object core extends Cross[CoreModule](versions.cross: _*)
-class CoreModule(val crossScalaVersion: String) extends CrossPlatform {
-    trait CommonModule extends CrossPlatformCrossScalaModule with CommonPublishModule {
-        override def artifactName = "poppet-core"
+        object jvm extends CommonModule with CommonPublishJvmModule {
+            object test extends CommonModuleTests with CommonPublishCrossModuleTests {
+                override def moduleDeps = super.moduleDeps ++ Seq(upickle().jvm)
+            }
+        }
 
-        trait CommonModuleTests extends Tests {
-            override def ivyDeps = super.ivyDeps() ++ Agg(
+        object js extends CommonModule with CommonPublishJsModule {
+            object test extends CommonModuleTests with CommonPublishCrossModuleTests {
+                override def moduleDeps = super.moduleDeps ++ Seq(upickle().js)
+            }
+        }
+
+        object native extends CommonModule with CommonPublishNativeModule {
+            object test extends CommonModuleTests with CommonPublishCrossModuleTests {
+                override def moduleDeps = super.moduleDeps ++ Seq(upickle().native)
+            }
+        }
+    }
+
+    object upickle extends Cross[UpickleModule](versions.cross: _*)
+    class UpickleModule(val crossScalaVersion: String) extends CrossPlatform {
+        trait CommonModule extends CrossPlatformCrossScalaModule with CommonPublishModule {
+            override def compileIvyDeps = super.compileIvyDeps() ++ Agg(
                 ivy"com.lihaoyi::upickle::${versions.upickle}",
             )
+
+            trait CommonModuleTests extends Tests {
+                override def ivyDeps = super.ivyDeps() ++ Agg(
+                    ivy"com.lihaoyi::upickle::${versions.upickle}",
+                )
+            }
+        }
+        override def moduleDeps = super.moduleDeps ++ Seq(core())
+
+        object jvm extends CommonModule with CommonPublishJvmModule {
+            object test extends CommonModuleTests with CommonPublishCrossModuleTests {
+                override def moduleDeps = super.moduleDeps ++ Seq(core().jvm.test)
+            }
+        }
+
+        object js extends CommonModule with CommonPublishJsModule {
+            object test extends CommonModuleTests with CommonPublishCrossModuleTests {
+                override def moduleDeps = super.moduleDeps ++ Seq(core().js.test)
+            }
+        }
+
+        object native extends CommonModule with CommonPublishNativeModule {
+            object test extends CommonModuleTests with CommonPublishCrossModuleTests {
+                override def moduleDeps = super.moduleDeps ++ Seq(core().native.test)
+            }
         }
     }
 
-    object jvm extends CommonModule with CommonPublishJvmModule {
-        object test extends CommonModuleTests with CommonPublishCrossModuleTests {
-            override def moduleDeps = super.moduleDeps ++ Seq(upickle().jvm)
-        }
-    }
-
-    object js extends CommonModule with CommonPublishJsModule {
-        object test extends CommonModuleTests with CommonPublishCrossModuleTests {
-            override def moduleDeps = super.moduleDeps ++ Seq(upickle().js)
-        }
-    }
-
-    object native extends CommonModule with CommonPublishNativeModule {
-        object test extends CommonModuleTests with CommonPublishCrossModuleTests {
-            override def moduleDeps = super.moduleDeps ++ Seq(upickle().native)
-        }
-    }
-}
-
-object upickle extends Cross[UpickleModule](versions.cross: _*)
-class UpickleModule(val crossScalaVersion: String) extends CrossPlatform {
-    trait CommonModule extends CrossPlatformCrossScalaModule with CommonPublishModule {
-        override def artifactName = "poppet-upickle"
-
-        override def compileIvyDeps = super.compileIvyDeps() ++ Agg(
-            ivy"com.lihaoyi::upickle::${versions.upickle}",
-        )
-
-        trait CommonModuleTests extends Tests {
-            override def ivyDeps = super.ivyDeps() ++ Agg(
-                ivy"com.lihaoyi::upickle::${versions.upickle}",
+    object circe extends Cross[CirceModule](versions.cross: _*)
+    class CirceModule(val crossScalaVersion: String) extends CrossPlatform {
+        trait CommonModule extends CrossPlatformCrossScalaModule with CommonPublishModule {
+            override def compileIvyDeps = super.compileIvyDeps() ++ Agg(
+                ivy"io.circe::circe-core::${versions.circe}"
             )
+
+            trait CommonModuleTests extends Tests {
+                override def ivyDeps = super.ivyDeps() ++ Agg(
+                    ivy"io.circe::circe-core::${versions.circe}",
+                    ivy"io.circe::circe-generic::${versions.circe}",
+                )
+            }
         }
-    }
-    override def moduleDeps = super.moduleDeps ++ Seq(core())
+        override def moduleDeps = super.moduleDeps ++ Seq(core())
 
-    object jvm extends CommonModule with CommonPublishJvmModule {
-        object test extends CommonModuleTests with CommonPublishCrossModuleTests {
-            override def moduleDeps = super.moduleDeps ++ Seq(core().jvm.test)
+        object jvm extends CommonModule with CommonPublishJvmModule {
+            object test extends CommonModuleTests with CommonPublishCrossModuleTests {
+                override def moduleDeps = super.moduleDeps ++ Seq(core().jvm.test)
+            }
         }
-    }
 
-    object js extends CommonModule with CommonPublishJsModule {
-        object test extends CommonModuleTests with CommonPublishCrossModuleTests {
-            override def moduleDeps = super.moduleDeps ++ Seq(core().js.test)
+        object js extends CommonModule with CommonPublishJsModule {
+            object test extends CommonModuleTests with CommonPublishCrossModuleTests {
+                override def moduleDeps = super.moduleDeps ++ Seq(core().js.test)
+            }
         }
-    }
 
-    object native extends CommonModule with CommonPublishNativeModule {
-        object test extends CommonModuleTests with CommonPublishCrossModuleTests {
-            override def moduleDeps = super.moduleDeps ++ Seq(core().native.test)
-        }
-    }
-}
-
-object circe extends Cross[CirceModule](versions.cross: _*)
-class CirceModule(val crossScalaVersion: String) extends CrossPlatform {
-    trait CommonModule extends CrossPlatformCrossScalaModule with CommonPublishModule {
-        override def artifactName = "poppet-circe"
-
-        override def compileIvyDeps = super.compileIvyDeps() ++ Agg(
-            ivy"io.circe::circe-core::${versions.circe}"
-        )
-
-        trait CommonModuleTests extends Tests {
-            override def ivyDeps = super.ivyDeps() ++ Agg(
-                ivy"io.circe::circe-core::${versions.circe}",
-                ivy"io.circe::circe-generic::${versions.circe}",
-            )
-        }
-    }
-    override def moduleDeps = super.moduleDeps ++ Seq(core())
-
-    object jvm extends CommonModule with CommonPublishJvmModule {
-        object test extends CommonModuleTests with CommonPublishCrossModuleTests {
-            override def moduleDeps = super.moduleDeps ++ Seq(core().jvm.test)
+        object native extends CommonModule with CommonPublishNativeModule {
+            object test extends CommonModuleTests with CommonPublishCrossModuleTests {
+                override def moduleDeps = super.moduleDeps ++ Seq(core().native.test)
+            }
         }
     }
 
-    object js extends CommonModule with CommonPublishJsModule {
-        object test extends CommonModuleTests with CommonPublishCrossModuleTests {
-            override def moduleDeps = super.moduleDeps ++ Seq(core().js.test)
-        }
-    }
-
-    object native extends CommonModule with CommonPublishNativeModule {
-        object test extends CommonModuleTests with CommonPublishCrossModuleTests {
-            override def moduleDeps = super.moduleDeps ++ Seq(core().native.test)
-        }
-    }
-}
-
-object `play-json` extends Cross[PlayJsonModule](versions.cross2: _*)
-class PlayJsonModule(val crossScalaVersion: String) extends CrossPlatform {
-    trait CommonModule extends CrossPlatformCrossScalaModule with CommonPublishModule {
-        override def artifactName = "poppet-play-json"
-
-        override def compileIvyDeps = super.compileIvyDeps() ++ Agg(
-            ivy"com.typesafe.play::play-json::${versions.playJson}",
-        )
-
-        trait CommonModuleTests extends Tests {
-            override def ivyDeps = super.ivyDeps() ++ Agg(
+    object `play-json` extends Cross[PlayJsonModule](versions.cross2: _*)
+    class PlayJsonModule(val crossScalaVersion: String) extends CrossPlatform {
+        trait CommonModule extends CrossPlatformCrossScalaModule with CommonPublishModule {
+            override def compileIvyDeps = super.compileIvyDeps() ++ Agg(
                 ivy"com.typesafe.play::play-json::${versions.playJson}",
             )
+
+            trait CommonModuleTests extends Tests {
+                override def ivyDeps = super.ivyDeps() ++ Agg(
+                    ivy"com.typesafe.play::play-json::${versions.playJson}",
+                )
+            }
+        }
+        override def moduleDeps = super.moduleDeps ++ Seq(core())
+
+        object jvm extends CommonModule with CommonPublishJvmModule {
+            object test extends CommonModuleTests with CommonPublishCrossModuleTests {
+                override def moduleDeps = super.moduleDeps ++ Seq(core().jvm.test)
+            }
+        }
+
+        object js extends CommonModule with CommonPublishJsModule {
+            object test extends CommonModuleTests with CommonPublishCrossModuleTests {
+                override def moduleDeps = super.moduleDeps ++ Seq(core().js.test)
+            }
         }
     }
-    override def moduleDeps = super.moduleDeps ++ Seq(core())
 
-    object jvm extends CommonModule with CommonPublishJvmModule {
-        object test extends CommonModuleTests with CommonPublishCrossModuleTests {
-            override def moduleDeps = super.moduleDeps ++ Seq(core().jvm.test)
-        }
-    }
-
-    object js extends CommonModule with CommonPublishJsModule {
-        object test extends CommonModuleTests with CommonPublishCrossModuleTests {
-            override def moduleDeps = super.moduleDeps ++ Seq(core().js.test)
-        }
-    }
-}
-
-object jackson extends Cross[JacksonModule](versions.cross: _*)
-class JacksonModule(val crossScalaVersion: String) extends CrossPlatform {
-    trait CommonModule extends CrossPlatformCrossScalaModule with CommonPublishModule {
-        override def artifactName = "poppet-jackson"
-
-        override def compileIvyDeps = super.compileIvyDeps() ++ Agg(
-            ivy"com.fasterxml.jackson.core:jackson-databind::${versions.jackson}",
-            ivy"com.fasterxml.jackson.module::jackson-module-scala::${versions.jackson}",
-        )
-
-        trait CommonModuleTests extends Tests {
-            override def ivyDeps = super.ivyDeps() ++ Agg(
+    object jackson extends Cross[JacksonModule](versions.cross: _*)
+    class JacksonModule(val crossScalaVersion: String) extends CrossPlatform {
+        trait CommonModule extends CrossPlatformCrossScalaModule with CommonPublishModule {
+            override def compileIvyDeps = super.compileIvyDeps() ++ Agg(
                 ivy"com.fasterxml.jackson.core:jackson-databind::${versions.jackson}",
                 ivy"com.fasterxml.jackson.module::jackson-module-scala::${versions.jackson}",
             )
-        }
-    }
-    override def moduleDeps = super.moduleDeps ++ Seq(core())
 
-    object jvm extends CommonModule with CommonPublishJvmModule {
-        object test extends CommonModuleTests with CommonPublishCrossModuleTests {
-            override def moduleDeps = super.moduleDeps ++ Seq(core().jvm.test)
+            trait CommonModuleTests extends Tests {
+                override def ivyDeps = super.ivyDeps() ++ Agg(
+                    ivy"com.fasterxml.jackson.core:jackson-databind::${versions.jackson}",
+                    ivy"com.fasterxml.jackson.module::jackson-module-scala::${versions.jackson}",
+                )
+            }
+        }
+        override def moduleDeps = super.moduleDeps ++ Seq(core())
+
+        object jvm extends CommonModule with CommonPublishJvmModule {
+            object test extends CommonModuleTests with CommonPublishCrossModuleTests {
+                override def moduleDeps = super.moduleDeps ++ Seq(core().jvm.test)
+            }
         }
     }
 }
-
 object example extends Module {
     object http4s extends Module {
         trait CommonModule extends ScalaModule {
@@ -249,7 +240,7 @@ object example extends Module {
                 ivy"org.typelevel::cats-effect::${versions.catsEffect}",
                 ivy"io.circe::circe-generic::${versions.circe}",
             )
-            override def moduleDeps = super.moduleDeps ++ Seq(circe(versions.scala3).jvm)
+            override def moduleDeps = super.moduleDeps ++ Seq(poppet.circe(versions.scala3).jvm)
         }
         object api extends CommonModule
         object consumer extends CommonModule {
@@ -280,7 +271,7 @@ object example extends Module {
                 ivy"org.typelevel::cats-core::${versions.cats}",
                 ivy"com.typesafe.play::play-json::${versions.playJson}",
             )
-            override def moduleDeps = super.moduleDeps ++ Seq(`play-json`(versions.scala213).jvm)
+            override def moduleDeps = super.moduleDeps ++ Seq(poppet.`play-json`(versions.scala213).jvm)
         }
         object api extends CommonModule
         object consumer extends CommonModule with PlayApiModule {
@@ -304,7 +295,7 @@ object example extends Module {
                 ivy"com.fasterxml.jackson.core:jackson-databind::${versions.jackson}",
                 ivy"com.fasterxml.jackson.module::jackson-module-scala::${versions.jackson}",
             )
-            override def moduleDeps = super.moduleDeps ++ Seq(jackson(versions.scala213).jvm)
+            override def moduleDeps = super.moduleDeps ++ Seq(poppet.jackson(versions.scala213).jvm)
             override def javacOptions = Seq("-source", "1.8", "-target", "1.8")
         }
         object api extends CommonModule


### PR DESCRIPTION
# Motivation

I was never happy with the way we define cross-platform modules in Mill. It is very verbose and full of duplication. After many failed attempts I managed to [write a plugin](https://github.com/lolgab/mill-crossplatform) that covered my needs.
To let people know about it, I decided to open PRs to big repositories to validate that the plugin covers the use cases of complex projects other than the ones of small ones.

## Tradeoffs

- \+ shorter build (20 lines less)
- \+ shared `moduleDeps` are defined once per module and always aligned between platforms
- \- there is no way to define shared test moduleDeps so you need to fallback to define them once per platform
- \- this way the build depends on a custom plugin and on some traits that have some semantics like `CrossPlatform` and `CrossPlatformCrossScalaModule`

## What to do with this PR

This PR was mostly an experiment to see if [mill-crossplatform](https://github.com/lolgab/mill-crossplatform) was able to make the build better. Feel free to drop it if you prefer the current build :)

I have to thank you since thanks to this build I noticed that `mill-crossplatform` didn't support `Cross.Resolver` to automatically pass `crossScalaVersion`, so I released a new version today to add it.